### PR TITLE
Fixes windows start batchfile having wrong installation path.

### DIFF
--- a/src/deflector.bat
+++ b/src/deflector.bat
@@ -1,6 +1,10 @@
 @echo off
 SETLOCAL
 
+:: ~dp0 gets the directory of the script
+:: .. is one directory up (moves from \bin up)
+SET TMPPATH=%~dp0..
+
 :: Check if the first argument is debug flag
 if "%1" == "-debug" (
     set DEBUG=-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=y
@@ -15,9 +19,6 @@ shift
 goto loop
 :afterloop
 
-:: ~dp0 gets the directory of the script
-:: .. is one directory up (moves from \bin up)
-SET TMPPATH=%~dp0..
 
 :: Resolve relative path by changing directory
 :: into relative path, getting the path with CD
@@ -29,10 +30,7 @@ POPD
 SET BIN=%BUILDTOOL_HOME%\bin
 SET LIB=%BUILDTOOL_HOME%\lib
 
-SET CLASSPATH=%BIN%\deflector-1.0.jar
-SET CLASSPATH=%CLASSPATH%;%LIB%\commons-io-2.4.jar
-SET CLASSPATH=%CLASSPATH%;%LIB%\commons-lang-2.6.jar
-SET CLASSPATH=%CLASSPATH%;%LIB%\jgrapht-core-0.9.0.jar
-SET CLASSPATH=%CLASSPATH%;%LIB%\commons-cli-1.2.jar
+SET CLASSPATH=%BIN%\*;%LIB%\*;
+
 
 "%JAVA_HOME%\bin\java" -Xmx1g -classpath "%CLASSPATH%" %DEBUG% ch.liquidmind.deflector.Main %PARAMS%


### PR DESCRIPTION
Wrong order caused the batch file to not recognize the correct installation path of deflector. Also simplified CLASSPATH resolution with asterix (*) notation.
